### PR TITLE
Add 3hole punch svg

### DIFF
--- a/faceshield-3hole-punch-short.svg
+++ b/faceshield-3hole-punch-short.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1440 864" style="enable-background:new 0 0 1440 864;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:none;stroke:#ED1C24;stroke-miterlimit:2.6131;}
+</style>
+<path class="st0" d="M73.53,0h689.94C784.11,0,802.2,16.23,801,36l1.64,432c-4.81,79.07-67.56,144-150.13,144H189
+	c-82.57,0-145.32-64.93-150.13-144L36,36C34.8,16.23,52.89,0,73.53,0z"/>
+<g>
+	<circle class="st0" cx="414" cy="27" r="9.06"/>
+	<circle class="st0" cx="107.94" cy="27.12" r="9.06"/>
+	<circle class="st0" cx="720.06" cy="27" r="9.06"/>
+</g>
+</svg>


### PR DESCRIPTION
Adds a short 3-hole punch compatible mask design tested on Glowforge with bonded 5mil laminate sheets (cut at 300 speed, 40% power)

Signed-off-by: Erica Windisch <73207+ewindisch@users.noreply.github.com>